### PR TITLE
Bug fixes for next release

### DIFF
--- a/ansible_dev/config_handler/ansible-dev.cfg
+++ b/ansible_dev/config_handler/ansible-dev.cfg
@@ -1,9 +1,9 @@
 [defaults]
 # Auto-generated defauls by default. DO not modify this
 venv_name ='.venv'
-ansible_version=devel
+ansible_version=stable-2.6
 ansible_repo=https://github.com/ansible/ansible.git
 python_version = 2
 # Below are Comma(,) seprated list
-galaxy_roles_list=ansible-network.network-engine
-git_roles_repos=https://github.com/ansible-network/cisco_ios
+galaxy_roles_list=ansible-network.network-engine, ansible-network.cisco_ios
+#git_roles_repos=https://github.com/ansible-network/cisco_ios

--- a/ansible_dev/config_handler/runner_home/project/playbook.yml
+++ b/ansible_dev/config_handler/runner_home/project/playbook.yml
@@ -3,10 +3,11 @@
 
 - hosts: all
   tasks:
-    - name: copy template inventory file to root of workspace
+    - name: copy template inventory file to root of workspace if it does not exist
       copy:
         src: '{{ templates_path }}/inventory.networking.template'
         dest: '{{ workspace_root }}/inventory'
+        force: no
 
     - name: Create the playbooks dir if it does not exist
       file:
@@ -56,3 +57,4 @@
       copy:
         src: '{{ templates_path }}/playbook.template'
         dest: '{{ cur_workdir }}/main.yml'
+        backup: yes

--- a/ansible_dev/context_manager/context.py
+++ b/ansible_dev/context_manager/context.py
@@ -113,9 +113,10 @@ class Context(object):
         self.get_all_context()
         if not len(self._contexts):
             click.secho("No workspace is created yet. Exiting", fg="red")
+            return
         # Set the context to first found workspace
         ctx = self._contexts[0]
-        self.current_ctx = CurrentConext(path=ctx["path"],
+        self.current_ctx = CurrentContext(path=ctx["path"],
             venv_name=ctx['venv'])
         self.set_persistent_current_context(path=ctx['path'], venv=ctx['venv'])
 

--- a/ansible_dev/lib/action.py
+++ b/ansible_dev/lib/action.py
@@ -208,6 +208,19 @@ class Action(object):
             os.chdir(repo_path)
         except (OSError, IOError) as e:
             raise e
+       
+        # Upgrade Pip first before installing ansible dependancies
+        # It caused pip install fail on some OS(es)
+        cmd = ['pip', 'install', '--upgrade',  'pip']
+        try:
+            rc, stdout = self.execute_command_in_venv(cmd)
+            rc, stdout = self._check_cmd_rc(rc, stdout)
+            self._log(level=2, msg="run_command : cmd=%s rc=%s" % (cmd, rc))
+            self._log(level=1, msg="Upgraded pip")
+        except Exception as e:
+            if self._verbose > 0:
+                traceback.print_exc()
+            pass
          
         requirements_path = os.path.join(repo_path, 'requirements.txt')
         cmd = ['pip', 'install' , '-r', requirements_path]

--- a/ansible_dev/lib/action.py
+++ b/ansible_dev/lib/action.py
@@ -208,8 +208,9 @@ class Action(object):
             os.chdir(repo_path)
         except (OSError, IOError) as e:
             raise e
-
-        cmd = ['pip', 'install' , '-r', 'requirements.txt']
+         
+        requirements_path = os.path.join(repo_path, 'requirements.txt')
+        cmd = ['pip', 'install' , '-r', requirements_path]
         try:
             rc, stdout = self.execute_command_in_venv(cmd)
             rc, stdout = self._check_cmd_rc(rc, stdout)

--- a/ansible_dev/lib/action.py
+++ b/ansible_dev/lib/action.py
@@ -157,12 +157,15 @@ class Action(object):
                 traceback.print_exc()
             raise e
 
-    def execute_command_in_venv(self, cmd, verbose=0):
+    def execute_command_in_venv(self, cmd, verbose=0, path=None):
         if verbose:
             old_verbose = self._verbose
             self._verbose = verbose
-
-        self._change_root_work_directory()
+        
+        if not path:
+            self._change_root_work_directory()
+        else:
+            os.chdir(path)
         venv_path = self._venv
         if venv_path is None:
             self._log(level=0, msg="venv is not yet created")
@@ -250,7 +253,7 @@ class Action(object):
 
         cmd = ['pip', 'install', '--editable', '.']
         try:
-            rc, stdout = self.execute_command_in_venv(cmd)
+            rc, stdout = self.execute_command_in_venv(cmd, path=ansible_path)
             rc, stdout = self._check_cmd_rc(rc, stdout)
             self._log(level=2, msg="run_command : cmd=%s rc=%s" % (cmd, rc))
             self._log(level=0, msg="Ansible installed from :%s" % ansible_path)

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ setup(
         'Click',
         'colorama',
         'docutils',
+        'configparser',
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Following bugs are fixed with this release 
1. change défault ansible version and default roles as per guidelines for network roles releases
2. ansible-dev ls does not work before init of any workspace
3. Pip install of ansible dependancies fails on old version of Centos
4. Do not overwrite inventory file of a playbook if customer has modified it
5. include dependancies of 'configparser' in setup.py 